### PR TITLE
Fix mapping of Assistant/Capture buttons

### DIFF
--- a/stadia.go
+++ b/stadia.go
@@ -134,8 +134,8 @@ func ParseReport(data []byte, report *Xbox360ControllerReport) error {
 		report.MaybeSetButton(Xbox360ControllerButtonStart, (b&0b0010_0000) != 0)
 		report.MaybeSetButton(Xbox360ControllerButtonGuide, (b&0b0001_0000) != 0)
 
-		report.Assistant = (b & 0b0000_0010) != 0
-		report.Capture = (b & 0b0000_0001) != 0
+		report.Assistant = (b & 0b0000_0001) != 0
+		report.Capture = (b & 0b0000_0010) != 0
 
 		// Update DPad buttons.
 		switch a {


### PR DESCRIPTION
## Summary
- correct swapped bitmask mapping for Stadia Capture and Assistant buttons

## Testing
- `go vet ./cmd` *(fails: build constraints exclude all Go files)*
- `env GOOS=windows go build ./cmd` *(fails: undefined references due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_685486776f208329b63281e95791284b